### PR TITLE
make custom reports scrollable when needed

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/helpers/generic-grid.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/helpers/generic-grid.js
@@ -92,7 +92,8 @@ pimcore.helpers.grid.buildDefaultPagingToolbar = function (store, options) {
         store: store,
         displayInfo: true,
         displayMsg: '{0} - {1} / {2}',
-        emptyMsg: t("no_items_found")
+        emptyMsg: t("no_items_found"),
+        scrollable: true
     };
     if (typeof options !== "undefined") {
         config = Ext.applyIf(options, config);


### PR DESCRIPTION
will now add a scrollbar if the panel is too small: 
![image](https://user-images.githubusercontent.com/105230931/200861996-0c9739cb-2501-401d-8426-730f9ce3529f.png)

resolves #1 