### PR TITLE
allow same name column on export

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/bundles/AdminBundle/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -1441,6 +1441,7 @@ class DataObjectHelperController extends AdminController
 
     public function encodeFunc($value)
     {
+        $value = $value['data'];
         $value = str_replace('"', '""', $value);
         //force wrap value in quotes and return
         return '"' . $value . '"';

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -1837,7 +1837,6 @@ class Service extends Model\Element\Service
         }
 
         if ($returnMappedFieldNames) {
-            $tmp = [];
             foreach ($mappedFieldnames as $key => $value) {
                 $objectData[$key]['fieldName'] = $value;
             }

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -1810,8 +1810,7 @@ class Service extends Model\Element\Service
     {
         $objectData = [];
         $mappedFieldnames = [];
-        $index = 0;
-        foreach ($fields as $field) {
+        foreach ($fields as $index => $field) {
             if (static::isHelperGridColumnConfig($field) && $validLanguages = static::expandGridColumnForExport($helperDefinitions, $field)) {
                 $currentLocale = $localeService->getLocale();
                 $mappedFieldnameBase = self::mapFieldname($field, $helperDefinitions);
@@ -1835,7 +1834,6 @@ class Service extends Model\Element\Service
 
                 $objectData[$index] = ['fieldName' => $field, 'data' => $fieldData];
             }
-            $index++;
         }
 
         if ($returnMappedFieldNames) {

--- a/models/DataObject/Service.php
+++ b/models/DataObject/Service.php
@@ -1810,6 +1810,7 @@ class Service extends Model\Element\Service
     {
         $objectData = [];
         $mappedFieldnames = [];
+        $index = 0;
         foreach ($fields as $field) {
             if (static::isHelperGridColumnConfig($field) && $validLanguages = static::expandGridColumnForExport($helperDefinitions, $field)) {
                 $currentLocale = $localeService->getLocale();
@@ -1819,29 +1820,29 @@ class Service extends Model\Element\Service
                     $localeService->setLocale($validLanguage);
                     $fieldData = self::getCsvFieldData($currentLocale, $field, $object, $validLanguage, $helperDefinitions);
                     $localizedFieldKey = $field . '-' . $validLanguage;
-                    if (!isset($mappedFieldnames[$localizedFieldKey])) {
-                        $mappedFieldnames[$localizedFieldKey] = $mappedFieldnameBase . '-' . $validLanguage;
+                    if (!isset($mappedFieldnames[$index])) {
+                        $mappedFieldnames[$index] = $mappedFieldnameBase . '-' . $validLanguage;
                     }
-                    $objectData[$localizedFieldKey] = $fieldData;
+                    $objectData[$index] = ['fieldName' => $localizedFieldKey, 'data' => $fieldData];
                 }
 
                 $localeService->setLocale($currentLocale);
             } else {
                 $fieldData = self::getCsvFieldData($requestedLanguage, $field, $object, $requestedLanguage, $helperDefinitions);
-                if (!isset($mappedFieldnames[$field])) {
-                    $mappedFieldnames[$field] = self::mapFieldname($field, $helperDefinitions);
+                if (!isset($mappedFieldnames[$index])) {
+                    $mappedFieldnames[$index] = self::mapFieldname($field, $helperDefinitions);
                 }
 
-                $objectData[$field] = $fieldData;
+                $objectData[$index] = ['fieldName' => $field, 'data' => $fieldData];
             }
+            $index++;
         }
 
         if ($returnMappedFieldNames) {
             $tmp = [];
             foreach ($mappedFieldnames as $key => $value) {
-                $tmp[$value] = $objectData[$key];
+                $objectData[$key]['fieldName'] = $value;
             }
-            $objectData = $tmp;
         }
 
         $event = new DataObjectEvent($object, ['objectData' => $objectData,
@@ -1883,8 +1884,8 @@ class Service extends Model\Element\Service
                 if ($addTitles && empty($data)) {
                     $tmp = [];
                     $mapped = self::getCsvDataForObject($object, $requestedLanguage, $fields, $helperDefinitions, $localeService, true, $context);
-                    foreach ($mapped as $key => $value) {
-                        $tmp[] = '"' . $key . '"';
+                    foreach ($mapped as $columns) {
+                        $tmp[] = '"' . $columns["fieldName"] . '"';
                     }
                     $data[] = $tmp;
                 }


### PR DESCRIPTION
Resolves #8

Use a unique index for each column of the export array instead of indexing based on column name. 

If desired, I could also add an option to the export panel to set custom header names, personally I think this should be split into a separate feature request. 