### PR TITLE
Docs/custom js code targeting

### DIFF
--- a/doc/Development_Documentation/18_Tools_and_Features/37_Targeting_and_Personalization/11_Frontend_Javascript.md
+++ b/doc/Development_Documentation/18_Tools_and_Features/37_Targeting_and_Personalization/11_Frontend_Javascript.md
@@ -91,7 +91,7 @@ The listener above sets a custom template which can either extend the core one o
 {% endblock %}
 ```
 
-Now, documents that activate a Code-Snippet Action that is set up under Marketing > Personalization / Targeting > Global Marketing Rules will include the block appended in our listener. 
+Now, users with a match on a targeting rule set up under Marketing > Personalization / Targeting > Global Marketing Rules will see the block appended in our listener. 
 
 ## Frontend Data Providers
 

--- a/doc/Development_Documentation/18_Tools_and_Features/37_Targeting_and_Personalization/11_Frontend_Javascript.md
+++ b/doc/Development_Documentation/18_Tools_and_Features/37_Targeting_and_Personalization/11_Frontend_Javascript.md
@@ -67,6 +67,14 @@ class TargetingCodeListener implements EventSubscriberInterface
 }
 ```
 
+Make sure to register the listener: 
+```yaml
+services:
+    App\EventListener\TargetingCodeListener:
+        tags:
+        - { name: kernel.event_listener }
+```
+
 The listener above sets a custom template which can either extend the core one or define a completely custom output:
 
 ```twig
@@ -82,6 +90,8 @@ The listener above sets a custom template which can either extend the core one o
     </script>
 {% endblock %}
 ```
+
+Now, documents that activate a Code-Snippet Action that is set up under Marketing > Global Marketing Rules will include the block appended in our listener. 
 
 ## Frontend Data Providers
 

--- a/doc/Development_Documentation/18_Tools_and_Features/37_Targeting_and_Personalization/11_Frontend_Javascript.md
+++ b/doc/Development_Documentation/18_Tools_and_Features/37_Targeting_and_Personalization/11_Frontend_Javascript.md
@@ -91,7 +91,7 @@ The listener above sets a custom template which can either extend the core one o
 {% endblock %}
 ```
 
-Now, documents that activate a Code-Snippet Action that is set up under Marketing > Global Marketing Rules will include the block appended in our listener. 
+Now, documents that activate a Code-Snippet Action that is set up under Marketing > Personalization / Targeting > Global Marketing Rules will include the block appended in our listener. 
 
 ## Frontend Data Providers
 


### PR DESCRIPTION
clarifies how to do the example and what it is achieving. 

to test: 

admin page > marketing > personalization 

> Global Targeting Rules: make a rule (you can leave everything in it blank)

add the two files in the docs 

render any document. 


please note: you may need to turn off addbockers for pimcore's targeting stuff to work. 