### PR TITLE
Bugfix/keybind overlap

### DIFF
--- a/bundles/AdminBundle/Controller/Admin/UserController.php
+++ b/bundles/AdminBundle/Controller/Admin/UserController.php
@@ -374,6 +374,7 @@ class UserController extends AdminController implements KernelControllerEventInt
                 $tmpArray[] = json_decode($item, true);
             }
             $tmpArray = array_values(array_filter($tmpArray));
+            $tmpArray = User::strictKeybinds($tmpArray);
             $tmpArray = json_encode($tmpArray);
 
             $user->setKeyBindings($tmpArray);

--- a/models/User.php
+++ b/models/User.php
@@ -990,6 +990,10 @@ final class User extends User\UserRole
         return $this->keyBindings ? $this->keyBindings : self::getDefaultKeyBindings();
     }
 
+    /**
+     * @param array|null
+     * @return array|null
+     */
     public static function strictKeybinds(null|array $bindings)
     {
         if($bindings == null){

--- a/models/User.php
+++ b/models/User.php
@@ -855,6 +855,7 @@ final class User extends User\UserRole
                     'action' => 'searchObject',
                     'key' => ord('O'),
                     'alt' => true,
+                    'ctrl' => false,
                 ],
                 [
                     'action' => 'showElementHistory',
@@ -979,7 +980,8 @@ final class User extends User\UserRole
                     'ctrl' => true,
                     'shift' => true,
                 ],
-            ]);
+            ]
+        );
     }
 
     /**

--- a/models/User.php
+++ b/models/User.php
@@ -994,7 +994,7 @@ final class User extends User\UserRole
      * @param array|null
      * @return array|null
      */
-    public static function strictKeybinds(null|array $bindings)
+    public static function strictKeybinds($bindings)
     {
         if($bindings == null){
             return null;

--- a/models/User.php
+++ b/models/User.php
@@ -775,213 +775,211 @@ final class User extends User\UserRole
      */
     public static function getDefaultKeyBindings()
     {
-        return json_encode(
+        $bindings = [
             [
-                [
-                    'action' => 'save',
-                    'key' => ord('S'),
-                    'ctrl' => true,
-                ],
-                [
-                    'action' => 'publish',
-                    'key' => ord('P'),
-                    'ctrl' => true,
-                    'shift' => true,
-                ],
-                [
-                    'action' => 'unpublish',
-                    'key' => ord('U'),
-                    'ctrl' => true,
-                    'shift' => true,
-                ],
-                [
-                    'action' => 'rename',
-                    'key' => ord('R'),
-                    'alt' => true,
-                    'shift' => true,
-                ],
-                [
-                    'action' => 'refresh',
-                    'key' => 116,
-                ],
-                [
-                    'action' => 'openAsset',
-                    'key' => ord('A'),
-                    'ctrl' => true,
-                    'shift' => true,
-                ],
-                [
-                    'action' => 'openObject',
-                    'key' => ord('O'),
-                    'ctrl' => true,
-                    'shift' => true,
-                ],
-                [
-                    'action' => 'openDocument',
-                    'key' => ord('D'),
-                    'ctrl' => true,
-                    'shift' => true,
-                ],
-                [
-                    'action' => 'openClassEditor',
-                    'key' => ord('C'),
-                    'ctrl' => true,
-                    'shift' => true,
+                'action' => 'save',
+                'key' => ord('S'),
+                'ctrl' => true,
+            ],
+            [
+                'action' => 'publish',
+                'key' => ord('P'),
+                'ctrl' => true,
+                'shift' => true,
+            ],
+            [
+                'action' => 'unpublish',
+                'key' => ord('U'),
+                'ctrl' => true,
+                'shift' => true,
+            ],
+            [
+                'action' => 'rename',
+                'key' => ord('R'),
+                'alt' => true,
+                'shift' => true,
+            ],
+            [
+                'action' => 'refresh',
+                'key' => 116,
+            ],
+            [
+                'action' => 'openAsset',
+                'key' => ord('A'),
+                'ctrl' => true,
+                'shift' => true,
+            ],
+            [
+                'action' => 'openObject',
+                'key' => ord('O'),
+                'ctrl' => true,
+                'shift' => true,
+            ],
+            [
+                'action' => 'openDocument',
+                'key' => ord('D'),
+                'ctrl' => true,
+                'shift' => true,
+            ],
+            [
+                'action' => 'openClassEditor',
+                'key' => ord('C'),
+                'ctrl' => true,
+                'shift' => true,
 
-                ],
-                [
-                    'action' => 'openInTree',
-                    'key' => ord('L'),
-                    'ctrl' => true,
-                    'shift' => true,
+            ],
+            [
+                'action' => 'openInTree',
+                'key' => ord('L'),
+                'ctrl' => true,
+                'shift' => true,
 
-                ],
-                [
-                    'action' => 'showMetaInfo',
-                    'key' => ord('I'),
-                    'alt' => true,
-                ],
-                [
-                    'action' => 'searchDocument',
-                    'key' => ord('W'),
-                    'alt' => true,
-                ],
-                [
-                    'action' => 'searchAsset',
-                    'key' => ord('A'),
-                    'alt' => true,
-                ],
-                [
-                    'action' => 'searchObject',
-                    'key' => ord('O'),
-                    'alt' => true,
-                    'ctrl' => false,
-                ],
-                [
-                    'action' => 'showElementHistory',
-                    'key' => ord('H'),
-                    'alt' => true,
-                ],
-                [
-                    'action' => 'closeAllTabs',
-                    'key' => ord('T'),
-                    'alt' => true,
-                ],
-                [
-                    'action' => 'searchAndReplaceAssignments',
-                    'key' => ord('S'),
-                    'alt' => true,
-                ],
-                [
-                    'action' => 'glossary',
-                    'key' => ord('G'),
-                    'shift' => true,
-                    'alt' => true,
-                ],
-                [
-                    'action' => 'redirects',
-                    'key' => ord('R'),
-                    'ctrl' => false,
-                    'alt' => true,
-                ],
-                [
-                    'action' => 'sharedTranslations',
-                    'key' => ord('T'),
-                    'ctrl' => true,
-                    'alt' => true,
-                ],
-                [
-                    'action' => 'recycleBin',
-                    'key' => ord('R'),
-                    'ctrl' => true,
-                    'alt' => true,
-                ],
-                [
-                    'action' => 'notesEvents',
-                    'key' => ord('N'),
-                    'ctrl' => true,
-                    'alt' => true,
-                ],
-                [
-                    'action' => 'applicationLogger',
-                    'key' => ord('L'),
-                    'ctrl' => true,
-                    'alt' => true,
-                ],
-                [
-                    'action' => 'reports',
-                    'key' => ord('M'),
-                    'ctrl' => true,
-                    'alt' => true,
-                ],
-                [
-                    'action' => 'tagManager',
-                    'key' => ord('H'),
-                    'ctrl' => true,
-                    'alt' => true,
-                ],
-                [
-                    'action' => 'seoDocumentEditor',
-                    'key' => ord('S'),
-                    'ctrl' => true,
-                    'alt' => true,
-                ],
-                [
-                    'action' => 'robots',
-                    'key' => ord('J'),
-                    'ctrl' => true,
-                    'alt' => true,
-                ],
-                [
-                    'action' => 'httpErrorLog',
-                    'key' => ord('O'),
-                    'ctrl' => true,
-                    'alt' => true,
-                ],
-                [
-                    'action' => 'customReports',
-                    'key' => ord('C'),
-                    'ctrl' => true,
-                    'alt' => true,
-                ],
-                [
-                    'action' => 'tagConfiguration',
-                    'key' => ord('N'),
-                    'ctrl' => true,
-                    'alt' => true,
-                ],
-                [
-                    'action' => 'users',
-                    'key' => ord('U'),
-                    'ctrl' => true,
-                    'alt' => true,
-                ],
-                [
-                    'action' => 'roles',
-                    'key' => ord('P'),
-                    'ctrl' => true,
-                    'alt' => true,
-                ],
-                [
-                    'action' => 'clearAllCaches',
-                    'key' => ord('Q'),
-                    'ctrl' => false,
-                    'alt' => true,
-                ],
-                [
-                    'action' => 'clearDataCache',
-                    'key' => ord('C'),
-                    'ctrl' => false,
-                    'alt' => true,
-                ],
-                [
-                    'action' => 'quickSearch',
-                    'key' => ord('F'),
-                    'ctrl' => true,
-                    'shift' => true,
-                ],
-            ]
-        );
+            ],
+            [
+                'action' => 'showMetaInfo',
+                'key' => ord('I'),
+                'alt' => true,
+            ],
+            [
+                'action' => 'searchDocument',
+                'key' => ord('W'),
+                'alt' => true,
+            ],
+            [
+                'action' => 'searchAsset',
+                'key' => ord('A'),
+                'alt' => true,
+            ],
+            [
+                'action' => 'searchObject',
+                'key' => ord('O'),
+                'alt' => true,
+            ],
+            [
+                'action' => 'showElementHistory',
+                'key' => ord('H'),
+                'alt' => true,
+            ],
+            [
+                'action' => 'closeAllTabs',
+                'key' => ord('T'),
+                'alt' => true,
+            ],
+            [
+                'action' => 'searchAndReplaceAssignments',
+                'key' => ord('S'),
+                'alt' => true,
+            ],
+            [
+                'action' => 'glossary',
+                'key' => ord('G'),
+                'shift' => true,
+                'alt' => true,
+            ],
+            [
+                'action' => 'redirects',
+                'key' => ord('R'),
+                'ctrl' => false,
+                'alt' => true,
+            ],
+            [
+                'action' => 'sharedTranslations',
+                'key' => ord('T'),
+                'ctrl' => true,
+                'alt' => true,
+            ],
+            [
+                'action' => 'recycleBin',
+                'key' => ord('R'),
+                'ctrl' => true,
+                'alt' => true,
+            ],
+            [
+                'action' => 'notesEvents',
+                'key' => ord('N'),
+                'ctrl' => true,
+                'alt' => true,
+            ],
+            [
+                'action' => 'applicationLogger',
+                'key' => ord('L'),
+                'ctrl' => true,
+                'alt' => true,
+            ],
+            [
+                'action' => 'reports',
+                'key' => ord('M'),
+                'ctrl' => true,
+                'alt' => true,
+            ],
+            [
+                'action' => 'tagManager',
+                'key' => ord('H'),
+                'ctrl' => true,
+                'alt' => true,
+            ],
+            [
+                'action' => 'seoDocumentEditor',
+                'key' => ord('S'),
+                'ctrl' => true,
+                'alt' => true,
+            ],
+            [
+                'action' => 'robots',
+                'key' => ord('J'),
+                'ctrl' => true,
+                'alt' => true,
+            ],
+            [
+                'action' => 'httpErrorLog',
+                'key' => ord('O'),
+                'ctrl' => true,
+                'alt' => true,
+            ],
+            [
+                'action' => 'customReports',
+                'key' => ord('C'),
+                'ctrl' => true,
+                'alt' => true,
+            ],
+            [
+                'action' => 'tagConfiguration',
+                'key' => ord('N'),
+                'ctrl' => true,
+                'alt' => true,
+            ],
+            [
+                'action' => 'users',
+                'key' => ord('U'),
+                'ctrl' => true,
+                'alt' => true,
+            ],
+            [
+                'action' => 'roles',
+                'key' => ord('P'),
+                'ctrl' => true,
+                'alt' => true,
+            ],
+            [
+                'action' => 'clearAllCaches',
+                'key' => ord('Q'),
+                'ctrl' => false,
+                'alt' => true,
+            ],
+            [
+                'action' => 'clearDataCache',
+                'key' => ord('C'),
+                'ctrl' => false,
+                'alt' => true,
+            ],
+            [
+                'action' => 'quickSearch',
+                'key' => ord('F'),
+                'ctrl' => true,
+                'shift' => true,
+            ],
+        ];
+        return json_encode(self::strictKeybinds($bindings));
     }
 
     /**
@@ -992,6 +990,24 @@ final class User extends User\UserRole
         return $this->keyBindings ? $this->keyBindings : self::getDefaultKeyBindings();
     }
 
+    public static function strictKeybinds(null|array $bindings)
+    {
+        if($bindings == null){
+            return null;
+        }
+        foreach($bindings as $ind => $binding){
+            if(!array_key_exists('ctrl', $binding)){
+                $bindings[$ind]['ctrl'] = false;
+            }
+            if(!array_key_exists('alt', $binding)){
+                $bindings[$ind]['alt'] = false;
+            }
+            if(!array_key_exists('shift', $binding)){
+                $bindings[$ind]['shift'] = false;
+            }
+        }
+        return $bindings;
+    }
     /**
      * @param string $keyBindings
      */

--- a/models/User.php
+++ b/models/User.php
@@ -991,7 +991,7 @@ final class User extends User\UserRole
     }
 
     /**
-     * @param array|null
+     * @param array|null $bindings
      * @return array|null
      */
     public static function strictKeybinds($bindings)


### PR DESCRIPTION
if a modifier button is not specified, its default is now strictly when not pressed. 

<img width="405" alt="image" src="https://user-images.githubusercontent.com/105230931/211043889-90dc50a6-cd39-44dd-9cab-985c7c732337.png">

now alt + ctrl + a will open neither tab