### PR TITLE
fix image gallery element 0 problems

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/imageGalleryDropZone.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/object/helpers/imageGalleryDropZone.js
@@ -69,7 +69,7 @@ Ext.define('pimcore.object.helpers.ImageGalleryDropZone', {
             var y = p.el.getY();
             var w = p.el.getWidth();
 
-            if(xy[1] >y && (xy[1] < (y + h)) && xy[0] > x && (xy[0] < (x + w))) {
+            if(pos != currentPosition && (xy[1] >y && (xy[1] < (y + h)) && xy[0] > x && (xy[0] < (x + w)))) {
                 match = true;
                 break;
             }else if (pos == len -1 && currentPosition != len - 1) {


### PR DESCRIPTION
Resolves #23

resolves an issue where trying to move an element(image) into the 0'th element slot would result in the image switching between the 0th image and the original location. 
https://gyazo.com/5211e02d03a9e4da0140c99780d0c87f