### PR TITLE
Update logException to accept Asset type for relatedObject

### DIFF
--- a/bundles/ApplicationLoggerBundle/src/ApplicationLogger.php
+++ b/bundles/ApplicationLoggerBundle/src/ApplicationLogger.php
@@ -292,7 +292,7 @@ class ApplicationLogger implements LoggerInterface
         $this->log($level, $message, $context);
     }
 
-    public function logException(string $message, Throwable $exceptionObject, ?string $priority = 'alert', \Pimcore\Model\DataObject\AbstractObject $relatedObject = null, string $component = null): void
+    public function logException(string $message, Throwable $exceptionObject, ?string $priority = 'alert', \Pimcore\Model\DataObject\AbstractObject|\Pimcore\Model\Asset|null $relatedObject = null, string $component = null): void
     {
         if (is_null($priority)) {
             $priority = 'alert';
@@ -318,7 +318,7 @@ class ApplicationLogger implements LoggerInterface
         string $message,
         Throwable $exception,
         int|string|Level $level = Level::Alert,
-        \Pimcore\Model\DataObject\AbstractObject $relatedObject = null,
+        \Pimcore\Model\DataObject\AbstractObject|\Pimcore\Model\Asset|null $relatedObject = null,
         array $context = []
     ): void {
         $message .= ' : ' . $exception->getMessage();


### PR DESCRIPTION
<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.5`
- Feature/Improvement: choose `12.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`12.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [ ] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [ ] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.4` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Allow the `logException` helper method to accept Assets in the relatedObject field like all the other log methods do.

## Additional info
